### PR TITLE
Activate manual bit-field support

### DIFF
--- a/version/Core/Private/Base.cpp
+++ b/version/Core/Private/Base.cpp
@@ -11,12 +11,12 @@ LPVOID GetAddress(const std::string& name)
 	return ArkApi::Offsets::Get().GetAddress(name);
 }
 
-//BitField GetBitField(const void* base, const std::string& structure, const std::string& offset)
-//{
-	//return ArkApi::Offsets::Get().GetBitField(base, structure, offset);
-//}
+BitField GetBitField(const void* base, const std::string& name)
+{
+	return ArkApi::Offsets::Get().GetBitField(base, name);
+}
 
-//BitField GetBitField(LPVOID base, const std::string& structure, const std::string& offset)
-//{
-	//return ArkApi::Hooks::Get().GetBitField(base, structure, offset);
-//}
+BitField GetBitField(LPVOID base, const std::string& name)
+{
+	return ArkApi::Offsets::Get().GetBitField(base, name);
+}

--- a/version/Core/Private/Offsets.cpp
+++ b/version/Core/Private/Offsets.cpp
@@ -18,9 +18,10 @@ namespace ArkApi
 		return instance;
 	}
 
-	void Offsets::Init(std::unordered_map<std::string, intptr_t>&& offsets_dump)
+	void Offsets::Init(std::unordered_map<std::string, intptr_t>&& offsets_dump, std::unordered_map<std::string, BitField>&& bitfields_dump)
 	{
 		offsets_dump_.swap(offsets_dump);
+		bitfields_dump_.swap(bitfields_dump);
 	}
 
 	DWORD64 Offsets::GetAddress(const void* base, const std::string& name)
@@ -31,5 +32,27 @@ namespace ArkApi
 	LPVOID Offsets::GetAddress(const std::string& name)
 	{
 		return reinterpret_cast<LPVOID>(module_base_ + static_cast<DWORD64>(offsets_dump_[name]));
+	}
+
+	BitField Offsets::GetBitField(const void* base, const std::string& name)
+	{
+		return GetBitFieldInternal(base, name);
+	}
+
+	BitField Offsets::GetBitField(LPVOID base, const std::string& name)
+	{
+		return GetBitFieldInternal(base, name);
+	}
+
+	BitField Offsets::GetBitFieldInternal(const void* base, const std::string& name)
+	{
+		auto bf = bitfields_dump_[name];
+		auto cf = BitField();
+		cf.bit_position = bf.bit_position;
+		cf.length = bf.length;
+		cf.num_bits = bf.num_bits;
+		cf.offset = reinterpret_cast<DWORD64>(base) + static_cast<DWORD64>(bf.offset);
+
+		return cf;
 	}
 }

--- a/version/Core/Private/Offsets.h
+++ b/version/Core/Private/Offsets.h
@@ -2,6 +2,7 @@
 
 #include <windows.h>
 #include <unordered_map>
+#include "../Public/API/Base.h"
 
 namespace ArkApi
 {
@@ -15,16 +16,22 @@ namespace ArkApi
 		Offsets& operator=(const Offsets&) = delete;
 		Offsets& operator=(Offsets&&) = delete;
 
-		void Init(std::unordered_map<std::string, intptr_t>&& offsets_dump);
+		void Init(std::unordered_map<std::string, intptr_t>&& offsets_dump, std::unordered_map<std::string, BitField>&& bitfields_dump);
 
 		DWORD64 GetAddress(const void* base, const std::string& name);
 		LPVOID GetAddress(const std::string& name);
+
+		BitField GetBitField(const void* base, const std::string& name);
+		BitField GetBitField(LPVOID base, const std::string& name);
 
 	private:
 		Offsets();
 		~Offsets() = default;
 
+		BitField GetBitFieldInternal(const void* base, const std::string& name);
+
 		DWORD64 module_base_;
 		std::unordered_map<std::string, intptr_t> offsets_dump_;
+		std::unordered_map<std::string, BitField> bitfields_dump_;
 	};
 }

--- a/version/Core/Private/PDBReader/PDBReader.cpp
+++ b/version/Core/Private/PDBReader/PDBReader.cpp
@@ -263,7 +263,7 @@ namespace ArkApi
 				if (type->get_length(&length) != S_OK)
 					return;
 
-				const BitField bit_field{offset, bit_position, num_bits, length};
+				const BitField bit_field{static_cast<DWORD64>(offset), bit_position, num_bits, length};
 
 				(*bitfields_dump_)[structure + "." + std::string(bbstr_name)] = bit_field;
 			}

--- a/version/Core/Public/API/Base.h
+++ b/version/Core/Public/API/Base.h
@@ -141,7 +141,7 @@ struct UStaticMesh;
 
 struct BitField
 {
-	LONG offset;
+	DWORD64 offset;
 	DWORD bit_position;
 	ULONGLONG num_bits;
 	ULONGLONG length; //in bytes
@@ -152,5 +152,5 @@ struct BitField
 ARK_API DWORD64 GetAddress(const void* base, const std::string& name);
 ARK_API LPVOID GetAddress(const std::string& name);
 
-//ARK_API BitField GetBitField(const void* base, const std::string& structure, const std::string& offset);
-//ARK_API BitField GetBitField(LPVOID base, const std::string& structure, const std::string& offset);
+ARK_API BitField GetBitField(const void* base, const std::string& name);
+ARK_API BitField GetBitField(LPVOID base, const std::string& name);

--- a/version/version.cpp
+++ b/version/version.cpp
@@ -62,7 +62,7 @@ void Init()
 		return;
 	}
 
-	Offsets::Get().Init(move(offsets_dump));
+	Offsets::Get().Init(move(offsets_dump), move(bitfields_dump));
 
 	InitHooks();
 


### PR DESCRIPTION
Even without pre-generated bit-fields in the api, I feel like having the option to manually add them is only a good thing. With this, I won't have to keep a fork of my own to support updating my plugins to v2.

Do you think this is a good way to implement it? BitFieldValue could be amended to work with a pointer like the other types, but I'm not sure how much sense it does to do so.